### PR TITLE
Remove DEV_HOST and PROD_HOST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,6 @@ NODE_ENV="development"
 SESSION_SECRET="SESSION_SECRET"
 ENCRYPTION_SECRET="ENCRYPTION_SECRET"
 
-# Host
-DEV_HOST_URL="http://localhost:3000"
-PROD_HOST_URL=""
-
 # Environment variables declared in this file are automatically made available to Prisma.
 # See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
 DATABASE_URL="file:./data.db?connection_limit=1"

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -5,9 +5,6 @@ const schema = z.object({
   SESSION_SECRET: z.string(),
   ENCRYPTION_SECRET: z.string(),
 
-  DEV_HOST_URL: z.string().optional(),
-  PROD_HOST_URL: z.string().optional(),
-
   DATABASE_URL: z.string(),
   RESEND_API_KEY: z.string(),
 })
@@ -34,10 +31,7 @@ export function initEnvs() {
  * to be included in the client.
  */
 export function getSharedEnvs() {
-  return {
-    DEV_HOST_URL: process.env.DEV_HOST_URL,
-    PROD_HOST_URL: process.env.PROD_HOST_URL,
-  }
+  return {}
 }
 
 type ENV = ReturnType<typeof getSharedEnvs>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "remix-auth": "^3.6.0",
-    "remix-auth-totp": "^1.0.3",
+    "remix-auth-totp": "^1.4.1",
     "zod": "^3.22.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove DEV_HOST_URL and PROD_HOST_URL from the environment because they are not used and could cause beginner confusion.